### PR TITLE
feat(cosmosutil): fix and change transaction signing to include timeout height.

### DIFF
--- a/node/config.go
+++ b/node/config.go
@@ -24,6 +24,7 @@ func recursiveModifyToml(c map[string]any, modifications Toml) error {
 			}
 			// Retrieve existing config to apply overrides to.
 			cVM, ok := cV.(map[string]any)
+
 			if !ok {
 				return fmt.Errorf("failed to convert section to (map[string]any), found (%T)", cV)
 			}
@@ -59,7 +60,12 @@ func GenerateDefaultConsensusConfig() Toml {
 	consensusConfig["timeout_commit"] = blockTime
 	consensusConfig["timeout_propose"] = blockTime
 
-	cometBftConfig["consensusConfig"] = consensusConfig
+	cometBftConfig["consensus"] = consensusConfig
+
+	instrumentationConfig := make(Toml)
+	instrumentationConfig["prometheus"] = true
+
+	cometBftConfig["instrumentation"] = instrumentationConfig
 
 	rpc := make(Toml)
 

--- a/node/node.go
+++ b/node/node.go
@@ -45,9 +45,9 @@ func CreateNode(ctx context.Context, nodeConfig petritypes.NodeConfig) (petrityp
 		Name:          nodeConfig.Name,
 		ContainerName: nodeConfig.Name,
 		Image:         chainConfig.Image,
-		Ports:         []string{"9090", "26656", "26657", "80"},
+		Ports:         []string{"9090", "26656", "26657", "26660", "80"},
 		Sidecars:      sidecars,
-		Command:       []string{"--home", chainConfig.HomeDir},
+		Entrypoint:    []string{chainConfig.BinaryName, "--home", chainConfig.HomeDir, "start"},
 		DataDir:       chainConfig.HomeDir,
 	}
 	task, err := provider.CreateTask(ctx, nodeConfig.Provider, def)


### PR DESCRIPTION
feat(cosmosutil): fix and change transaction signing to include timeout height.

additionally, refactor the signing methodology into: create -> sign -> broadcast instead of create -> broadcast

Update cosmosutil/auth.go

Co-authored-by: Alex Johnson <alex@djinntek.world>

feat(cosmosutil): fix and change transaction signing to include timeout height.

additionally, refactor the signing methodology into: create -> sign -> broadcast instead of create -> broadcast