### PR TITLE
Add debug logs

### DIFF
--- a/core/provider/docker/volume.go
+++ b/core/provider/docker/volume.go
@@ -238,14 +238,14 @@ func (p *Provider) ReadFile(ctx context.Context, id, relPath string) ([]byte, er
 
 	logger.Debug("created getfile container", zap.String("id", cc.ID))
 
-	//defer func() {
-	//	if err := p.dockerClient.ContainerRemove(ctx, cc.ID, types.ContainerRemoveOptions{
-	//		Force: true,
-	//	}); err != nil {
-	//      logger.Error("failed cleaning up the getfile container", zap.Error(err))
-	//		// todo fix logging
-	//	}
-	//}()
+	defer func() {
+		if err := p.dockerClient.ContainerRemove(ctx, cc.ID, types.ContainerRemoveOptions{
+			Force: true,
+		}); err != nil {
+			logger.Error("failed cleaning up the getfile container", zap.Error(err))
+			// todo fix logging
+		}
+	}()
 
 	logger.Debug("copying from container")
 	rc, _, err := p.dockerClient.CopyFromContainer(ctx, cc.ID, path.Join(mountPath, relPath))

--- a/core/provider/docker/volume.go
+++ b/core/provider/docker/volume.go
@@ -267,7 +267,6 @@ func (p *Provider) ReadFile(ctx context.Context, id, relPath string) ([]byte, er
 			return nil, fmt.Errorf("reading tar from container: %w", err)
 		}
 		if hdr.Name != wantPath {
-			// todo fix logging
 			continue
 		}
 

--- a/cosmos/node/genesis.go
+++ b/cosmos/node/genesis.go
@@ -72,7 +72,8 @@ func (n *Node) AddGenesisAccount(ctx context.Context, address string, genesisAmo
 	command = append(command, "add-genesis-account", address, amount)
 	command = n.BinCommand(command...)
 
-	_, _, _, err := n.Task.RunCommand(ctx, command)
+	stdout, stderr, exitCode, err := n.Task.RunCommand(ctx, command)
+	n.logger.Debug("add-genesis-account", zap.String("stdout", stdout), zap.String("stderr", stderr), zap.Int("exitCode", exitCode))
 
 	if err != nil {
 		return err
@@ -99,7 +100,8 @@ func (n *Node) GenerateGenTx(ctx context.Context, genesisSelfDelegation types.Co
 
 	command = n.BinCommand(command...)
 
-	_, stderr, exitCode, err := n.Task.RunCommand(ctx, command)
+	stdout, stderr, exitCode, err := n.Task.RunCommand(ctx, command)
+	n.logger.Debug("gentx", zap.String("stdout", stdout), zap.String("stderr", stderr), zap.Int("exitCode", exitCode))
 
 	if exitCode != 0 {
 		return fmt.Errorf("failed to generate genesis transaction: %s (exitcode=%d)", stderr, exitCode)
@@ -112,17 +114,16 @@ func (n *Node) GenerateGenTx(ctx context.Context, genesisSelfDelegation types.Co
 func (n *Node) CollectGenTxs(ctx context.Context) error {
 	n.logger.Info("collecting genesis transactions", zap.String("node", n.Definition.Name))
 
-	chainConfig := n.chain.GetConfig()
-
 	command := []string{}
 
 	if n.chain.GetConfig().UseGenesisSubCommand {
 		command = append(command, "genesis")
 	}
 
-	command = append(command, "collect-gentxs", "--home", chainConfig.HomeDir)
+	command = append(command, "collect-gentxs")
 
-	_, _, _, err := n.Task.RunCommand(ctx, n.BinCommand(command...))
+	stdout, stderr, exitCode, err := n.Task.RunCommand(ctx, n.BinCommand(command...))
+	n.logger.Debug("collect-gentxs", zap.String("stdout", stdout), zap.String("stderr", stderr), zap.Int("exitCode", exitCode))
 
 	return err
 }

--- a/cosmos/node/init.go
+++ b/cosmos/node/init.go
@@ -10,7 +10,8 @@ func (n *Node) InitHome(ctx context.Context) error {
 	n.logger.Info("initializing home", zap.String("name", n.Definition.Name))
 	chainConfig := n.chain.GetConfig()
 
-	_, _, _, err := n.Task.RunCommand(ctx, n.BinCommand([]string{"init", n.Definition.Name, "--chain-id", chainConfig.ChainId}...))
+	stdout, stderr, exitCode, err := n.Task.RunCommand(ctx, n.BinCommand([]string{"init", n.Definition.Name, "--chain-id", chainConfig.ChainId}...))
+	n.logger.Debug("init home", zap.String("stdout", stdout), zap.String("stderr", stderr), zap.Int("exitCode", exitCode))
 
 	return err
 }

--- a/cosmos/node/keys.go
+++ b/cosmos/node/keys.go
@@ -58,6 +58,7 @@ func (n *Node) KeyBech32(ctx context.Context, name, bech string) (string, error)
 	}
 
 	stdout, stderr, _, err := n.Task.RunCommand(ctx, command)
+	n.logger.Debug("show key", zap.String("name", name), zap.String("stdout", stdout), zap.String("stderr", stderr))
 
 	if err != nil {
 		return "", fmt.Errorf("failed to show key %q (stderr=%q): %w", name, stderr, err)


### PR DESCRIPTION
Add debug logs on any commands run on the nodes.

Most of the commands don't actually return non-zero when they fail--they all just log things to stderr. Adding debug logs gives much better visibility.

Also uncommented a cleanup function. And removed `--home` from `collect-gentxs` since the `node::BinCommand` function already wraps the command with the home flag.