### PR TITLE
fix(core/provider/digitalocean): make the droplets and containers map threadsafe

### DIFF
--- a/core/go.mod
+++ b/core/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/docker/go-connections v0.4.0
 	github.com/go-rod/rod v0.114.6
 	github.com/pkg/sftp v1.13.6
+	github.com/puzpuzpuz/xsync/v3 v3.0.2
 	github.com/spf13/afero v1.11.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.16.0

--- a/core/go.sum
+++ b/core/go.sum
@@ -631,6 +631,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.3.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/puzpuzpuz/xsync/v3 v3.0.2 h1:3yESHrRFYr6xzkz61LLkvNiPFXxJEAABanTQpKbAaew=
+github.com/puzpuzpuz/xsync/v3 v3.0.2/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/core/provider/digitalocean/digitalocean_provider.go
+++ b/core/provider/digitalocean/digitalocean_provider.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"fmt"
 	"github.com/digitalocean/godo"
+	"github.com/puzpuzpuz/xsync/v3"
 	"github.com/skip-mev/petri/core/v2/provider"
 	"github.com/skip-mev/petri/core/v2/util"
 	"go.uber.org/zap"
@@ -28,8 +29,9 @@ type Provider struct {
 
 	sshPubKey, sshPrivKey, sshFingerprint string
 
-	droplets   map[string]*godo.Droplet
-	containers map[string]string
+	droplets   *xsync.MapOf[string, *godo.Droplet]
+	containers *xsync.MapOf[string, string]
+
 	firewallID string
 }
 
@@ -58,8 +60,8 @@ func NewDigitalOceanProvider(ctx context.Context, logger *zap.Logger, providerNa
 
 		userIPs: userIPs,
 
-		droplets:   map[string]*godo.Droplet{},
-		containers: map[string]string{},
+		droplets:   xsync.NewMapOf[string, *godo.Droplet](),
+		containers: xsync.NewMapOf[string, string](),
 
 		sshPubKey:      sshPubKey,
 		sshPrivKey:     sshPrivKey,

--- a/core/provider/digitalocean/droplet.go
+++ b/core/provider/digitalocean/droplet.go
@@ -94,7 +94,7 @@ func (p *Provider) CreateDroplet(ctx context.Context, definition provider.TaskDe
 }
 
 func (p *Provider) deleteDroplet(ctx context.Context, name string) error {
-	cachedDroplet, ok := p.droplets[name]
+	cachedDroplet, ok := p.droplets.Load(name)
 
 	if !ok {
 		return fmt.Errorf("could not find droplet %s", name)
@@ -114,7 +114,7 @@ func (p *Provider) deleteDroplet(ctx context.Context, name string) error {
 }
 
 func (p *Provider) getDroplet(ctx context.Context, name string) (*godo.Droplet, error) {
-	cachedDroplet, ok := p.droplets[name]
+	cachedDroplet, ok := p.droplets.Load(name)
 
 	if !ok {
 		return nil, fmt.Errorf("could not find droplet %s", name)

--- a/core/provider/digitalocean/task.go
+++ b/core/provider/digitalocean/task.go
@@ -42,7 +42,7 @@ func (p *Provider) CreateTask(ctx context.Context, logger *zap.Logger, definitio
 		return "", err
 	}
 
-	p.droplets[droplet.Name] = droplet
+	p.droplets.Store(droplet.Name, droplet)
 
 	ip, err := p.GetIP(ctx, droplet.Name)
 
@@ -92,7 +92,7 @@ func (p *Provider) CreateTask(ctx context.Context, logger *zap.Logger, definitio
 		return "", err
 	}
 
-	p.containers[droplet.Name] = createdContainer.ID
+	p.containers.Store(droplet.Name, createdContainer.ID)
 
 	return droplet.Name, nil
 }
@@ -106,7 +106,7 @@ func (p *Provider) StartTask(ctx context.Context, taskName string) error {
 		return err
 	}
 
-	containerID, ok := p.containers[taskName]
+	containerID, ok := p.containers.Load(taskName)
 
 	if !ok {
 		return fmt.Errorf("could not find container for %s with ID %s", taskName, containerID)
@@ -143,7 +143,7 @@ func (p *Provider) StopTask(ctx context.Context, taskName string) error {
 		return err
 	}
 
-	containerID, ok := p.containers[taskName]
+	containerID, ok := p.containers.Load(taskName)
 
 	if !ok {
 		return fmt.Errorf("could not find container for %s with ID %s", taskName, containerID)
@@ -185,7 +185,7 @@ func (p *Provider) GetTaskStatus(ctx context.Context, taskName string) (provider
 
 	defer dockerClient.Close()
 
-	id, ok := p.containers[taskName]
+	id, ok := p.containers.Load(taskName)
 
 	if !ok {
 		return provider.TASK_STATUS_UNDEFINED, fmt.Errorf("could not find container for %s with ID %s", taskName, id)
@@ -318,7 +318,7 @@ func (p *Provider) RunCommand(ctx context.Context, taskName string, command []st
 
 	defer dockerClient.Close()
 
-	id, ok := p.containers[taskName]
+	id, ok := p.containers.Load(taskName)
 
 	if !ok {
 		return "", "", 0, fmt.Errorf("could not find container for %s with ID %s", taskName, id)


### PR DESCRIPTION
Part of BLO-817 - if you create two tasks concurrently using the DigitalOcean provider, it's possible to run into race conditions. That shouldn't happen as long as you never create two tasks with the same name (which shouldn't be possible either), but it's good practice.