### PR TITLE
fix(core/provider): add RWMutex to task operations

### DIFF
--- a/core/provider/provider.go
+++ b/core/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"go.uber.org/zap"
+	"sync"
 )
 
 // TaskStatus defines the status of a task's underlying workload
@@ -23,8 +24,8 @@ type Task struct {
 	Definition TaskDefinition
 	Sidecars   []*Task
 
-	logger *zap.Logger
-
+	logger   *zap.Logger
+	mu       sync.RWMutex
 	PreStart func(context.Context, *Task) error
 	PostStop func(context.Context, *Task) error
 }


### PR DESCRIPTION
Part of BLO-617 - adds locks to operations on Tasks. This effectively means that you should always use Tasks instead of the Providers directly, as tasks will provide concurrency safety.

I tried to take care when choosing an RLock vs a regular Lock, but please review that I'm correct