### PR TITLE
Remove unnecessary args

### DIFF
--- a/cosmos/loadtest/client_factory.go
+++ b/cosmos/loadtest/client_factory.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/cometbft/cometbft/test/loadtime/payload"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/informalsystems/tm-load-test/pkg/loadtest"
 
 	petritypes "github.com/skip-mev/petri/core/v2/types"
@@ -41,7 +40,7 @@ type ClientFactoryConfig struct {
 	MsgGenerator          GenerateMsgs
 }
 
-func NewDefaultClientFactory(cfg ClientFactoryConfig, mbm module.BasicManager) (*DefaultClientFactory, error) {
+func NewDefaultClientFactory(cfg ClientFactoryConfig) *DefaultClientFactory {
 	return &DefaultClientFactory{
 		chain:            cfg.Chain,
 		chainClient:      &cosmosutil.ChainClient{Chain: cfg.Chain},
@@ -51,7 +50,7 @@ func NewDefaultClientFactory(cfg ClientFactoryConfig, mbm module.BasicManager) (
 		walletConfig:     cfg.WalletConfig,
 		encodingConfig:   cfg.EncodingConfig,
 		msgGenerator:     cfg.MsgGenerator,
-	}, nil
+	}
 }
 
 // NewClient implements the ClientFactory's interface for creating new clients.


### PR DESCRIPTION
The mbm and returned error seem unnecessary in this context. You probably need to register the module interfaces with the message generator, but it's not happening within the creation function currently, and I'm not sure it needs to?

Also, there's no possibility of erroring in this function right now.