### PR TITLE
feat: refactor provider and task

### DIFF
--- a/core/provider/provider.go
+++ b/core/provider/provider.go
@@ -48,13 +48,14 @@ type TaskI interface {
 	GetExternalAddress(context.Context, string) (string, error)
 
 	RunCommand(context.Context, []string) (string, string, int, error)
-	RunCommandWhileStopped(context.Context, []string) (string, string, int, error)
 }
 
 type ProviderI interface {
 	CreateTask(context.Context, TaskDefinition) (TaskI, error) // should this create a TaskI or the resources behind it?
 	SerializeTask(context.Context, TaskI) ([]byte, error)
 	DeserializeTask(context.Context, []byte) (TaskI, error)
+
+	Teardown(context.Context) error
 
 	SerializeProvider(context.Context) ([]byte, error)
 }

--- a/core/provider/provider.go
+++ b/core/provider/provider.go
@@ -30,12 +30,42 @@ type Task struct {
 	PostStop func(context.Context, *Task) error
 }
 
+type TaskI interface {
+	Initialize(context.Context) error
+	Start(context.Context) error
+	Stop(context.Context) error
+	Destroy(context.Context) error
+
+	GetStatus(context.Context) (TaskStatus, error)
+
+	Modify(context.Context, TaskDefinition) error
+
+	WriteFile(context.Context, string, []byte) error
+	ReadFile(context.Context, string) ([]byte, error)
+	DownloadDir(context.Context, string, string) error
+
+	GetIP(context.Context) (string, error)
+	GetExternalAddress(context.Context, string) (string, error)
+
+	RunCommand(context.Context, []string) (string, string, int, error)
+	RunCommandWhileStopped(context.Context, []string) (string, string, int, error)
+}
+
+type ProviderI interface {
+	CreateTask(context.Context, TaskDefinition) (TaskI, error) // should this create a TaskI or the resources behind it?
+	SerializeTask(context.Context, TaskI) ([]byte, error)
+	DeserializeTask(context.Context, []byte) (TaskI, error)
+
+	SerializeProvider(context.Context) ([]byte, error)
+}
+
 // Provider is the representation of any infrastructure provider that can handle
 // running arbitrary Docker workloads
 type Provider interface {
 	CreateTask(context.Context, *zap.Logger, TaskDefinition) (string, error)
 	StartTask(context.Context, string) error
 	StopTask(context.Context, string) error
+	ModifyTask(context.Context, string, TaskDefinition) error
 	DestroyTask(context.Context, string) error
 
 	GetTaskStatus(context.Context, string) (TaskStatus, error)


### PR DESCRIPTION
This PR achieves two things by refactoring the Task and Provider interfaces:

* it makes a task more than just a container for state (that we didn't really use anyways)
* it enables serialization of provider and task state - useful for stateless workloads that are not single-use tests (e.g. long-running testnets)