### PR TITLE
feat: rewrite the docker provider

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
           go work init
           go work use ./cosmos ./core 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/core/go.mod
+++ b/core/go.mod
@@ -8,14 +8,12 @@ require (
 	github.com/cilium/ipam v0.0.0-20230509084518-fd66eae7909b
 	github.com/cometbft/cometbft v0.38.12
 	github.com/cosmos/cosmos-sdk v0.50.10
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/digitalocean/godo v1.108.0
 	github.com/docker/docker v27.1.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/go-rod/rod v0.114.6
 	github.com/golangci/golangci-lint v1.56.2
 	github.com/matoous/go-nanoid/v2 v2.1.0
-	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.6
 	github.com/puzpuzpuz/xsync/v3 v3.4.0
@@ -98,6 +96,7 @@ require (
 	github.com/curioswitch/go-reassign v0.2.0 // indirect
 	github.com/daixiang0/gci v0.12.1 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/denis-tingaikin/go-header v0.4.3 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect

--- a/core/go.sum
+++ b/core/go.sum
@@ -570,8 +570,6 @@ github.com/gostaticanalysis/nilerr v0.1.1/go.mod h1:wZYb6YI5YAxxq0i1+VJbY0s2YONW
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.4.0 h1:nhdCmubdmDF6VEatUNjgUZBJKWRqugoISdUv3PPQgHY=
 github.com/gostaticanalysis/testutil v0.4.0/go.mod h1:bLIoPefWXrRi/ssLFWX1dx7Repi5x3CuviD3dgAZaBU=
-github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
-github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
@@ -866,8 +864,6 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/ory/dockertest v3.3.5+incompatible h1:iLLK6SQwIhcbrG783Dghaaa3WPzGc+4Emza6EbVUUGA=
-github.com/ory/dockertest v3.3.5+incompatible/go.mod h1:1vX4m9wsvi00u5bseYwXaSnhNrne+V0E6LAcBILJdPs=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
 github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
@@ -1657,8 +1653,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
-gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
 gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/core/provider/docker/network.go
+++ b/core/provider/docker/network.go
@@ -143,8 +143,6 @@ func (p *Provider) nextAvailableIp() (string, error) {
 		return "", err
 	}
 
-	p.state.AllocatedIPs = append(p.state.AllocatedIPs, ip.To4().String())
-
 	return ip.String(), nil
 }
 

--- a/core/provider/docker/network.go
+++ b/core/provider/docker/network.go
@@ -1,0 +1,173 @@
+package docker
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"net"
+
+	"github.com/docker/docker/api/types/network"
+	"go.uber.org/zap"
+
+	"github.com/docker/go-connections/nat"
+)
+
+const providerLabelName = "petri-provider"
+
+func (p *Provider) initNetwork(ctx context.Context) (network.Inspect, error) {
+	p.logger.Info("creating network", zap.String("name", p.state.NetworkName))
+	subnet1 := rand.Intn(255)
+	subnet2 := rand.Intn(255)
+
+	networkResponse, err := p.dockerClient.NetworkCreate(ctx, p.state.NetworkName, network.CreateOptions{
+		Scope:  "local",
+		Driver: "bridge",
+		Options: map[string]string{ // https://docs.docker.com/engine/reference/commandline/network_create/#bridge-driver-options
+			"com.docker.network.bridge.enable_icc":           "true",
+			"com.docker.network.bridge.enable_ip_masquerade": "true",
+			"com.docker.network.bridge.host_binding_ipv4":    "0.0.0.0",
+			"com.docker.network.driver.mtu":                  "1500",
+		},
+		Internal:   false,
+		Attachable: false,
+		Ingress:    false,
+		Labels: map[string]string{
+			providerLabelName: p.state.Name,
+		},
+		IPAM: &network.IPAM{
+			Driver: "default",
+			Config: []network.IPAMConfig{
+				{
+					Subnet:  fmt.Sprintf("192.%d.%d.0/24", subnet1, subnet2),
+					Gateway: fmt.Sprintf("192.%d.%d.1", subnet1, subnet2),
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		return network.Inspect{}, err
+	}
+
+	networkInfo, err := p.dockerClient.NetworkInspect(ctx, networkResponse.ID, network.InspectOptions{})
+	if err != nil {
+		return network.Inspect{}, err
+	}
+
+	return networkInfo, nil
+}
+
+// ensureNetwork checks if the network exists and has the expected configuration.
+func (p *Provider) ensureNetwork(ctx context.Context) error {
+	network, err := p.dockerClient.NetworkInspect(ctx, p.state.NetworkID, network.InspectOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	if network.ID != p.state.NetworkID {
+		return fmt.Errorf("network ID mismatch: %s != %s", network.ID, p.state.NetworkID)
+	}
+
+	if network.Name != p.state.NetworkName {
+		return fmt.Errorf("network name mismatch: %s != %s", network.Name, p.state.NetworkName)
+	}
+
+	if len(network.IPAM.Config) != 1 {
+		return fmt.Errorf("unexpected number of IPAM configs: %d", len(network.IPAM.Config))
+	}
+
+	if network.IPAM.Config[0].Subnet != p.state.NetworkCIDR {
+		return fmt.Errorf("network CIDR mismatch: %s != %s", network.IPAM.Config[0].Subnet, p.state.NetworkCIDR)
+	}
+
+	return nil
+}
+
+func (p *Provider) destroyNetwork(ctx context.Context) error {
+	if err := p.dockerClient.NetworkRemove(ctx, p.state.NetworkID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// openListenerOnFreePort opens the next free port
+func (p *Provider) openListenerOnFreePort() (*net.TCPListener, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	p.networkMu.Lock()
+	defer p.networkMu.Unlock()
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+// nextAvailablePort generates a docker PortBinding by finding the next available port.
+// The listener will be closed in the case of an error, otherwise it will be left open.
+// This allows multiple nextAvailablePort calls to find multiple available ports
+// before closing them so they are available for the PortBinding.
+func (p *Provider) nextAvailablePort() (nat.PortBinding, *net.TCPListener, error) {
+	l, err := p.openListenerOnFreePort()
+	if err != nil {
+		if l != nil {
+			if err := l.Close(); err != nil {
+				return nat.PortBinding{}, nil, err
+			}
+		}
+
+		return nat.PortBinding{}, nil, err
+	}
+
+	return nat.PortBinding{
+		HostIP:   "0.0.0.0",
+		HostPort: fmt.Sprint(l.Addr().(*net.TCPAddr).Port),
+	}, l, nil
+}
+
+func (p *Provider) nextAvailableIp() (string, error) {
+	p.networkMu.Lock()
+	p.stateMu.Lock()
+	defer p.networkMu.Unlock()
+	defer p.stateMu.Unlock()
+
+	ip, err := p.dockerNetworkAllocator.AllocateNext()
+
+	if err != nil {
+		return "", err
+	}
+
+	p.state.AllocatedIPs = append(p.state.AllocatedIPs, ip.To4().String())
+
+	return ip.String(), nil
+}
+
+// GeneratePortBindings will find open ports on the local
+// machine and create a PortBinding for every port in the portSet.
+func (p *Provider) GeneratePortBindings(portSet nat.PortSet) (nat.PortMap, error) {
+	m := make(nat.PortMap)
+
+	for port := range portSet {
+		pb, l, err := p.nextAvailablePort()
+
+		if err != nil {
+			return nat.PortMap{}, err
+		}
+
+		err = l.Close()
+
+		if err != nil {
+			return nat.PortMap{}, err
+		}
+
+		m[port] = []nat.PortBinding{pb}
+	}
+
+	return m, nil
+}

--- a/core/provider/docker/network.go
+++ b/core/provider/docker/network.go
@@ -85,11 +85,7 @@ func (p *Provider) ensureNetwork(ctx context.Context) error {
 }
 
 func (p *Provider) destroyNetwork(ctx context.Context) error {
-	if err := p.dockerClient.NetworkRemove(ctx, p.state.NetworkID); err != nil {
-		return err
-	}
-
-	return nil
+	return p.dockerClient.NetworkRemove(ctx, p.state.NetworkID)
 }
 
 // openListenerOnFreePort opens the next free port
@@ -131,7 +127,7 @@ func (p *Provider) nextAvailablePort() (nat.PortBinding, *net.TCPListener, error
 	}, l, nil
 }
 
-func (p *Provider) nextAvailableIp() (string, error) {
+func (p *Provider) nextAvailableIP() (string, error) {
 	p.networkMu.Lock()
 	p.stateMu.Lock()
 	defer p.networkMu.Unlock()

--- a/core/provider/docker/provider.go
+++ b/core/provider/docker/provider.go
@@ -210,7 +210,7 @@ func (p *Provider) CreateTask(ctx context.Context, definition provider.TaskDefin
 	logger.Debug("creating container", zap.String("name", definition.Name), zap.String("image", definition.Image.Image))
 
 	// network map is volatile, so we need to mutex update it
-	ip, err := p.nextAvailableIp()
+	ip, err := p.nextAvailableIP()
 	if err != nil {
 		return nil, err
 	}

--- a/core/provider/docker/provider.go
+++ b/core/provider/docker/provider.go
@@ -1,0 +1,358 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/docker/docker/api/types/image"
+	"github.com/skip-mev/petri/core/v2/provider"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/cilium/ipam/service/ipallocator"
+	"github.com/docker/docker/api/types/network"
+	"go.uber.org/zap"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+
+	"github.com/docker/docker/client"
+)
+
+type ProviderState struct {
+	TaskStates map[string]*TaskState `json:"task_states"`
+
+	Name string `json:"name"`
+
+	NetworkID    string   `json:"network_id"`
+	NetworkName  string   `json:"network_name"`
+	NetworkCIDR  string   `json:"network_cidr"`
+	AllocatedIPs []string `json:"allocated_ips"`
+
+	BuilderImageName string `json:"builder_image_name"`
+}
+
+type Provider struct {
+	state   *ProviderState
+	stateMu sync.Mutex
+
+	dockerClient           *client.Client
+	dockerNetworkAllocator *ipallocator.Range
+	networkMu              sync.Mutex
+	logger                 *zap.Logger
+}
+
+var _ provider.ProviderI = (*Provider)(nil)
+
+func CreateProvider(ctx context.Context, logger *zap.Logger, providerName string) (*Provider, error) {
+	dockerClient, err := client.NewClientWithOpts()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = dockerClient.Ping(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if providerName == "" {
+		return nil, fmt.Errorf("provider name cannot be empty")
+	}
+
+	state := ProviderState{
+		Name:             providerName,
+		BuilderImageName: "busybox:latest",
+		NetworkName:      fmt.Sprintf("petri-network-%s", providerName),
+		TaskStates:       make(map[string]*TaskState),
+	}
+
+	dockerProvider := &Provider{
+		dockerClient: dockerClient,
+		state:        &state,
+		logger:       logger,
+	}
+
+	network, err := dockerProvider.initNetwork(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	dockerProvider.state.NetworkID = network.ID
+
+	_, cidrMask, err := net.ParseCIDR(network.IPAM.Config[0].Subnet)
+	if err != nil {
+		return nil, err
+	}
+
+	dockerProvider.state.NetworkCIDR = cidrMask.String()
+
+	dockerProvider.dockerNetworkAllocator, err = ipallocator.NewCIDRRange(cidrMask)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return dockerProvider, nil
+}
+
+func RestoreProvider(ctx context.Context, state []byte) (*Provider, error) {
+	var providerState ProviderState
+
+	err := json.Unmarshal(state, &providerState)
+
+	if err != nil {
+		return nil, err
+	}
+
+	dockerProvider := &Provider{
+		state: &providerState,
+	}
+
+	dockerClient, err := client.NewClientWithOpts()
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = dockerClient.Ping(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	dockerProvider.dockerClient = dockerClient
+	_, cidrMask, err := net.ParseCIDR(providerState.NetworkCIDR)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse cidr mask from state: %w", err)
+	}
+
+	dockerProvider.dockerNetworkAllocator, err = ipallocator.NewCIDRRange(cidrMask)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ip allocator from state: %w", err)
+	}
+
+	for _, ip := range providerState.AllocatedIPs {
+		if err := dockerProvider.dockerNetworkAllocator.Allocate(net.ParseIP(ip)); err != nil {
+			return nil, fmt.Errorf("failed to restore ip allocator state: %w", err)
+		}
+	}
+
+	if err := dockerProvider.ensureNetwork(ctx); err != nil {
+		return nil, fmt.Errorf("failed to reconcilliate the docker network: %w", err)
+	}
+
+	return dockerProvider, nil
+}
+
+func (p *Provider) CreateTask(ctx context.Context, definition provider.TaskDefinition) (provider.TaskI, error) {
+	if err := definition.ValidateBasic(); err != nil {
+		return &Task{}, fmt.Errorf("failed to validate task definition: %w", err)
+	}
+
+	taskState := &TaskState{
+		Name:       definition.Name,
+		Definition: definition,
+	}
+
+	logger := p.logger.Named("docker_provider")
+
+	if err := p.pullImage(ctx, definition.Image.Image); err != nil {
+		return nil, err
+	}
+
+	portSet := convertTaskDefinitionPortsToPortSet(definition)
+	portBindings, err := p.GeneratePortBindings(portSet)
+	if err != nil {
+		return nil, fmt.Errorf("failed to allocate task ports: %v", err)
+	}
+
+	var mounts []mount.Mount
+
+	logger.Debug("creating task", zap.String("name", definition.Name), zap.String("image", definition.Image.Image))
+
+	if definition.DataDir != "" {
+		volumeName := fmt.Sprintf("%s-data", definition.Name)
+
+		logger.Debug("creating volume", zap.String("name", volumeName))
+
+		_, err = p.CreateVolume(ctx, provider.VolumeDefinition{
+			Name:      volumeName,
+			Size:      "10GB",
+			MountPath: definition.DataDir,
+		})
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to create dataDir: %v", err)
+		}
+
+		volumeMount := mount.Mount{
+			Type:   mount.TypeVolume,
+			Source: volumeName,
+			Target: definition.DataDir,
+		}
+
+		logger.Debug("setting volume owner", zap.String("name", volumeName), zap.String("uid", definition.Image.UID), zap.String("gid", definition.Image.GID))
+
+		if err = p.SetVolumeOwner(ctx, volumeName, definition.Image.UID, definition.Image.GID); err != nil {
+			return nil, fmt.Errorf("failed to set volume owner: %v", err)
+		}
+
+		mounts = []mount.Mount{volumeMount}
+
+		taskState.Volume = &VolumeState{
+			Name: volumeName,
+			Size: "10GB",
+		}
+	}
+
+	logger.Debug("creating container", zap.String("name", definition.Name), zap.String("image", definition.Image.Image))
+
+	// network map is volatile, so we need to mutex update it
+	ip, err := p.nextAvailableIp()
+	if err != nil {
+		return nil, err
+	}
+
+	createdContainer, err := p.dockerClient.ContainerCreate(ctx, &container.Config{
+		Image:      definition.Image.Image,
+		Entrypoint: definition.Entrypoint,
+		Cmd:        definition.Command,
+		Tty:        false,
+		Hostname:   definition.Name,
+		Labels: map[string]string{
+			providerLabelName: p.state.Name,
+		},
+		Env: convertEnvMapToList(definition.Environment),
+	}, &container.HostConfig{
+		Mounts:          mounts,
+		PortBindings:    portBindings,
+		PublishAllPorts: true,
+		NetworkMode:     container.NetworkMode(p.state.NetworkName),
+	}, &network.NetworkingConfig{
+		EndpointsConfig: map[string]*network.EndpointSettings{
+			p.state.NetworkName: {
+				IPAMConfig: &network.EndpointIPAMConfig{
+					IPv4Address: ip,
+				},
+			},
+		},
+	}, nil, definition.ContainerName)
+
+	if err != nil {
+		return nil, err
+	}
+
+	taskState.Id = createdContainer.ID
+	taskState.Status = provider.TASK_STOPPED
+
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+
+	p.state.TaskStates[taskState.Id] = taskState
+
+	return &Task{
+		state:    taskState,
+		provider: p,
+	}, nil
+}
+
+func (p *Provider) SerializeProvider(context.Context) ([]byte, error) {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+
+	bz, err := json.Marshal(p.state)
+
+	return bz, err
+}
+
+func (p *Provider) SerializeTask(ctx context.Context, task provider.TaskI) ([]byte, error) {
+	if _, ok := task.(*Task); !ok {
+		return nil, fmt.Errorf("task is not a Docker task")
+	}
+
+	dockerTask := task.(*Task)
+
+	bz, err := json.Marshal(dockerTask.state)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return bz, nil
+}
+
+func (p *Provider) DeserializeTask(ctx context.Context, bz []byte) (provider.TaskI, error) {
+	var taskState TaskState
+
+	err := json.Unmarshal(bz, &taskState)
+	if err != nil {
+		return nil, err
+	}
+
+	task := &Task{
+		provider: p,
+		state:    &taskState,
+	}
+
+	if err := task.ensureTask(ctx); err != nil {
+		return nil, err
+	}
+
+	return task, nil
+}
+
+func (p *Provider) removeTask(_ context.Context, taskID string) error {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+
+	delete(p.state.TaskStates, taskID)
+
+	return nil
+}
+
+func (p *Provider) pullImage(ctx context.Context, imageName string) error {
+	_, _, err := p.dockerClient.ImageInspectWithRaw(ctx, imageName)
+	if err != nil {
+		p.logger.Info("image not found, pulling", zap.String("image", imageName))
+		resp, err := p.dockerClient.ImagePull(ctx, imageName, image.PullOptions{})
+		if err != nil {
+			return err
+		}
+		defer resp.Close()
+
+		// throw away the image pull stdout response
+		_, err = io.Copy(io.Discard, resp)
+		return err
+	}
+	return nil
+}
+
+func (p *Provider) Teardown(ctx context.Context) error {
+	p.logger.Info("tearing down Docker provider")
+
+	for _, task := range p.state.TaskStates {
+		if err := p.dockerClient.ContainerRemove(ctx, task.Id, container.RemoveOptions{
+			Force: true,
+		}); err != nil {
+			return err
+		}
+	}
+
+	if err := p.teardownVolumes(ctx); err != nil {
+		return err
+	}
+
+	if err := p.destroyNetwork(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *Provider) GetState() ProviderState {
+	p.stateMu.Lock()
+	defer p.stateMu.Unlock()
+	return *p.state
+}

--- a/core/provider/docker/provider_test.go
+++ b/core/provider/docker/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/matoous/go-nanoid/v2"
 	"github.com/skip-mev/petri/core/v2/provider/docker"
+	"go.uber.org/zap/zaptest"
 	"sync"
 	"testing"
 	"time"
@@ -15,7 +16,6 @@ import (
 	"github.com/skip-mev/petri/core/v2/provider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 const idAlphabet = "abcdefghijklqmnoqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
@@ -39,7 +39,7 @@ func setupTest(tb testing.TB, name string) func(testing.TB, string) {
 
 func TestCreateProviderDuplicateNetwork(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
 	teardown := setupTest(t, providerName)
@@ -58,7 +58,7 @@ func TestCreateProviderDuplicateNetwork(t *testing.T) {
 
 func TestCreateProvider(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
 	teardown := setupTest(t, providerName)
@@ -79,7 +79,7 @@ func TestCreateProvider(t *testing.T) {
 
 func TestRestoreProvider(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
 	teardown := setupTest(t, providerName)
@@ -100,7 +100,7 @@ func TestRestoreProvider(t *testing.T) {
 }
 
 func TestCreateTask(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 	ctx := context.Background()
 
@@ -177,7 +177,7 @@ func TestConcurrentTaskCreation(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
 	p, err := docker.CreateProvider(ctx, logger, providerName)
@@ -243,7 +243,7 @@ func TestConcurrentTaskCreation(t *testing.T) {
 
 func TestProviderSerialization(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
@@ -274,7 +274,7 @@ func TestProviderSerialization(t *testing.T) {
 
 func TestTeardown(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 	p, err := docker.CreateProvider(ctx, logger, providerName)
 	require.NoError(t, err)
@@ -299,7 +299,7 @@ func TestTeardown(t *testing.T) {
 
 func TestRestoreTask(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
 	teardown := setupTest(t, providerName)

--- a/core/provider/docker/provider_test.go
+++ b/core/provider/docker/provider_test.go
@@ -1,0 +1,312 @@
+package docker_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/matoous/go-nanoid/v2"
+	"github.com/skip-mev/petri/core/v2/provider/docker"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/skip-mev/petri/core/v2/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const idAlphabet = "abcdefghijklqmnoqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
+
+func setupTest(tb testing.TB, name string) func(testing.TB, string) {
+	return func(tb testing.TB, name string) {
+		client, _ := client.NewClientWithOpts()
+
+		nets, _ := client.NetworkList(context.Background(), network.ListOptions{
+			Filters: filters.NewArgs(filters.Arg("name", fmt.Sprintf("petri-network-%s", name))),
+		})
+
+		if len(nets) != 0 {
+			for _, net := range nets {
+				client.NetworkRemove(context.Background(), net.ID)
+			}
+		}
+	}
+}
+
+func TestCreateProviderDuplicateNetwork(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+
+	teardown := setupTest(t, providerName)
+	defer teardown(t, providerName)
+
+	p1, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+	defer p1.Teardown(ctx)
+
+	p2, err := docker.CreateProvider(ctx, logger, providerName)
+	require.Error(t, err)
+	require.Nil(t, p2)
+}
+
+func TestCreateProvider(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+
+	teardown := setupTest(t, providerName)
+	defer teardown(t, providerName)
+
+	p, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+	defer p.Teardown(ctx)
+
+	state := p.GetState()
+	assert.Equal(t, providerName, state.Name)
+	assert.NotEmpty(t, state.NetworkID)
+	assert.NotEmpty(t, state.NetworkName)
+	assert.NotEmpty(t, state.NetworkCIDR)
+}
+
+func TestRestoreProvider(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+
+	teardown := setupTest(t, providerName)
+	defer teardown(t, providerName)
+
+	p1, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+
+	state1 := p1.GetState()
+	serialized, err := p1.SerializeProvider(ctx)
+	require.NoError(t, err)
+
+	p2, err := docker.RestoreProvider(ctx, serialized)
+	require.NoError(t, err)
+
+	state2 := p2.GetState()
+	assert.Equal(t, state1, state2)
+}
+
+func TestCreateTask(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+	p, err := docker.CreateProvider(context.Background(), logger, providerName)
+	require.NoError(t, err)
+	defer p.Teardown(context.Background())
+
+	tests := []struct {
+		name       string
+		definition provider.TaskDefinition
+		wantErr    bool
+		errorMsg   string
+	}{
+		{
+			name: "success",
+			definition: provider.TaskDefinition{
+				Name:          fmt.Sprintf("%s-test-task-success", providerName),
+				ContainerName: fmt.Sprintf("%s-test-task-success", providerName),
+				Image:         provider.ImageDefinition{Image: "busybox:latest", GID: "1000", UID: "1000"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing image",
+			definition: provider.TaskDefinition{
+				Name:          fmt.Sprintf("%s-test-task-no-image", providerName),
+				ContainerName: fmt.Sprintf("%s-test-task-no-image", providerName),
+			},
+			wantErr:  true,
+			errorMsg: "image cannot be empty",
+		},
+		{
+			name: "invalid image",
+			definition: provider.TaskDefinition{
+				Name:          fmt.Sprintf("%s-test-task-bad-image", providerName),
+				ContainerName: fmt.Sprintf("%s-test-task-bad-image", providerName),
+				Image:         provider.ImageDefinition{Image: "busybox:latest"},
+			},
+			wantErr:  true,
+			errorMsg: "image definition is invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			task, err := p.CreateTask(context.Background(), tt.definition)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errorMsg != "" {
+					assert.Contains(t, err.Error(), tt.errorMsg)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+
+			dockerTask, ok := task.(*docker.Task)
+			assert.True(t, ok)
+			assert.NotNil(t, dockerTask)
+
+			state := dockerTask.GetState()
+			assert.NotEmpty(t, state.Id)
+			assert.Equal(t, tt.definition.Name, state.Name)
+		})
+	}
+}
+
+func TestConcurrentTaskCreation(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+	p, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+	defer p.Teardown(ctx)
+
+	numTasks := 10
+	var wg sync.WaitGroup
+	errors := make(chan error, numTasks)
+	tasks := make(chan *docker.Task, numTasks)
+
+	for i := 0; i < numTasks; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			task, err := p.CreateTask(ctx, provider.TaskDefinition{
+				Name:          fmt.Sprintf("task-%s-%d", providerName, index),
+				ContainerName: fmt.Sprintf("task-%s-%d", providerName, index),
+				Image:         provider.ImageDefinition{Image: "busybox:latest", GID: "1000", UID: "1000"},
+				Entrypoint:    []string{"sh", "-c"},
+				Command:       []string{"sleep 1000"},
+			})
+			if err != nil {
+				errors <- err
+				return
+			}
+
+			err = task.Start(ctx)
+			if err != nil {
+				errors <- err
+				return
+			}
+			tasks <- task.(*docker.Task)
+		}(i)
+	}
+
+	wg.Wait()
+	close(errors)
+	close(tasks)
+
+	for err := range errors {
+		assert.NoError(t, err)
+	}
+
+	providerState := p.GetState()
+	ips := make(map[string]bool)
+
+	for task := range tasks {
+		taskState := task.GetState()
+		client, _ := client.NewClientWithOpts()
+		containerJSON, err := client.ContainerInspect(ctx, taskState.Id)
+		require.NoError(t, err)
+
+		ip := containerJSON.NetworkSettings.Networks[providerState.NetworkName].IPAddress
+		fmt.Println(ip)
+		assert.False(t, ips[ip], "Duplicate IP found: %s", ip)
+		ips[ip] = true
+	}
+}
+
+func TestProviderSerialization(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+	p1, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+	defer p1.Teardown(ctx)
+
+	_, err = p1.CreateTask(ctx, provider.TaskDefinition{
+		Name:          fmt.Sprintf("%s-test-task", providerName),
+		ContainerName: fmt.Sprintf("%s-test-task", providerName),
+		Image:         provider.ImageDefinition{Image: "busybox:latest", GID: "1000", UID: "1000"},
+	})
+	require.NoError(t, err)
+
+	state1 := p1.GetState()
+	serialized, err := p1.SerializeProvider(ctx)
+	require.NoError(t, err)
+
+	p2, err := docker.RestoreProvider(ctx, serialized)
+	require.NoError(t, err)
+
+	state2 := p2.GetState()
+	assert.Equal(t, state1, state2)
+}
+
+func TestTeardown(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+	p, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+
+	task, err := p.CreateTask(ctx, provider.TaskDefinition{
+		Name:          fmt.Sprintf("%s-test-task-teardown", providerName),
+		ContainerName: fmt.Sprintf("%s-test-task-teardown", providerName),
+		Image:         provider.ImageDefinition{Image: "busybox:latest", GID: "1000", UID: "1000"},
+		DataDir:       "/data",
+	})
+	require.NoError(t, err)
+
+	dockerTask := task.(*docker.Task)
+	taskState := dockerTask.GetState()
+	err = p.Teardown(ctx)
+	assert.NoError(t, err)
+
+	client, _ := client.NewClientWithOpts()
+	_, err = client.ContainerInspect(ctx, taskState.Id)
+	assert.Error(t, err)
+}
+
+func TestRestoreTask(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+
+	teardown := setupTest(t, providerName)
+	defer teardown(t, providerName)
+
+	p, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+
+	task, err := p.CreateTask(ctx, provider.TaskDefinition{
+		Name:          fmt.Sprintf("%s-test-task-restore", providerName),
+		ContainerName: fmt.Sprintf("%s-test-task-restore", providerName),
+		Image:         provider.ImageDefinition{Image: "busybox:latest", GID: "1000", UID: "1000"},
+		DataDir:       "/data",
+	})
+
+	dockerTask := task.(*docker.Task)
+
+	state, err := p.SerializeTask(ctx, task)
+	require.NoError(t, err)
+
+	restoredTask, err := p.DeserializeTask(ctx, state)
+	require.NoError(t, err)
+
+	restoredDockerTask, ok := restoredTask.(*docker.Task)
+	require.True(t, ok)
+	require.NotNil(t, restoredDockerTask)
+	require.Equal(t, dockerTask.GetState(), restoredDockerTask.GetState())
+}

--- a/core/provider/docker/task.go
+++ b/core/provider/docker/task.go
@@ -103,9 +103,9 @@ func (t *Task) Destroy(ctx context.Context) error {
 	return nil
 }
 
-func (t *Task) ensure(_ context.Context) error {
-	return nil
-}
+//func (t *Task) ensure(_ context.Context) error {
+//	return nil
+//}
 
 func (t *Task) GetExternalAddress(ctx context.Context, port string) (string, error) {
 	t.provider.logger.Debug("getting external address", zap.String("id", t.state.Id))

--- a/core/provider/docker/task.go
+++ b/core/provider/docker/task.go
@@ -26,6 +26,7 @@ type TaskState struct {
 	Volume     *VolumeState            `json:"volumes"`
 	Definition provider.TaskDefinition `json:"definition"`
 	Status     provider.TaskStatus     `json:"status"`
+	IpAddress  string                  `json:"ip_address"`
 }
 
 type VolumeState struct {

--- a/core/provider/docker/task.go
+++ b/core/provider/docker/task.go
@@ -103,10 +103,6 @@ func (t *Task) Destroy(ctx context.Context) error {
 	return nil
 }
 
-//func (t *Task) ensure(_ context.Context) error {
-//	return nil
-//}
-
 func (t *Task) GetExternalAddress(ctx context.Context, port string) (string, error) {
 	t.provider.logger.Debug("getting external address", zap.String("id", t.state.Id))
 
@@ -189,12 +185,8 @@ func (t *Task) GetStatus(ctx context.Context) (provider.TaskStatus, error) {
 	return provider.TASK_STATUS_UNDEFINED, nil
 }
 
-func (t *Task) Initialize(ctx context.Context) error {
-	return nil
-}
-
 func (t *Task) Modify(ctx context.Context, td provider.TaskDefinition) error {
-	return nil
+	panic("unimplemented")
 }
 
 func (t *Task) RunCommand(ctx context.Context, cmd []string) (string, string, int, error) {

--- a/core/provider/docker/task.go
+++ b/core/provider/docker/task.go
@@ -1,0 +1,353 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/docker/go-connections/nat"
+	"github.com/skip-mev/petri/core/v2/util"
+	"sync"
+	// "github.com/docker/docker/api/types/filters"
+	// "github.com/docker/docker/api/types/image"
+	// "github.com/docker/docker/api/types/mount"
+	// "github.com/docker/docker/api/types/network"
+	// "github.com/docker/docker/pkg/stdcopy"
+	// "github.com/docker/go-connections/nat"
+	"github.com/skip-mev/petri/core/v2/provider"
+	"go.uber.org/zap"
+	"time"
+)
+
+type TaskState struct {
+	Id         string                  `json:"id"`
+	Name       string                  `json:"name"`
+	Volume     *VolumeState            `json:"volumes"`
+	Definition provider.TaskDefinition `json:"definition"`
+	Status     provider.TaskStatus     `json:"status"`
+}
+
+type VolumeState struct {
+	Name string `json:"name"`
+	Size string `json:"size"`
+}
+
+type Task struct {
+	state    *TaskState
+	stateMu  sync.Mutex
+	provider *Provider
+}
+
+var _ provider.TaskI = (*Task)(nil)
+
+func (t *Task) Start(ctx context.Context) error {
+	t.provider.logger.Info("starting task", zap.String("id", t.state.Id))
+
+	err := t.provider.dockerClient.ContainerStart(ctx, t.state.Id, container.StartOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	if err := t.WaitForStatus(ctx, 1*time.Second, provider.TASK_RUNNING); err != nil {
+		return err
+	}
+
+	t.stateMu.Lock()
+	defer t.stateMu.Unlock()
+
+	t.state.Status = provider.TASK_RUNNING
+
+	return nil
+}
+
+func (t *Task) Stop(ctx context.Context) error {
+	t.provider.logger.Info("stopping task", zap.String("id", t.state.Id))
+
+	err := t.provider.dockerClient.ContainerStop(ctx, t.state.Id, container.StopOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	if err := t.WaitForStatus(ctx, 1*time.Second, provider.TASK_STOPPED); err != nil {
+		return err
+	}
+
+	t.stateMu.Lock()
+	defer t.stateMu.Unlock()
+
+	t.state.Status = provider.TASK_STOPPED
+
+	return nil
+}
+
+func (t *Task) Destroy(ctx context.Context) error {
+	t.provider.logger.Info("destroying task", zap.String("id", t.state.Id))
+
+	err := t.provider.dockerClient.ContainerRemove(ctx, t.state.Id, container.RemoveOptions{
+		Force:         true,
+		RemoveVolumes: true,
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if err := t.provider.removeTask(ctx, t.state.Id); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *Task) ensure(_ context.Context) error {
+	return nil
+}
+
+func (t *Task) GetExternalAddress(ctx context.Context, port string) (string, error) {
+	t.provider.logger.Debug("getting external address", zap.String("id", t.state.Id))
+
+	dockerContainer, err := t.provider.dockerClient.ContainerInspect(ctx, t.state.Id)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to inspect container: %w", err)
+	}
+
+	ip, err := t.GetIP(ctx)
+
+	if err != nil {
+		return "", fmt.Errorf("failed to get IP: %w", err)
+	}
+
+	portBindings, ok := dockerContainer.NetworkSettings.Ports[nat.Port(fmt.Sprintf("%s/tcp", port))]
+
+	if !ok || len(portBindings) == 0 {
+		return "", fmt.Errorf("port %s not found", port)
+	}
+
+	return fmt.Sprintf("%s:%s", ip, portBindings[0].HostPort), nil
+}
+
+func (t *Task) GetIP(ctx context.Context) (string, error) {
+	t.provider.logger.Debug("getting IP", zap.String("id", t.state.Id))
+
+	dockerContainer, err := t.provider.dockerClient.ContainerInspect(ctx, t.state.Id)
+	if err != nil {
+		return "", err
+	}
+
+	ip := dockerContainer.NetworkSettings.Networks[t.provider.state.NetworkName].IPAMConfig.IPv4Address
+
+	return ip, nil
+}
+
+func (t *Task) WaitForStatus(ctx context.Context, interval time.Duration, desiredStatus provider.TaskStatus) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			status, err := t.GetStatus(ctx)
+			if err != nil {
+				return err
+			}
+
+			if status == desiredStatus {
+				return nil
+			}
+			time.Sleep(interval)
+		}
+	}
+}
+
+func (t *Task) GetStatus(ctx context.Context) (provider.TaskStatus, error) {
+	containerJSON, err := t.provider.dockerClient.ContainerInspect(ctx, t.state.Id)
+	if err != nil {
+		return provider.TASK_STATUS_UNDEFINED, err
+	}
+
+	fmt.Println(containerJSON.State.Status)
+
+	switch state := containerJSON.State.Status; state {
+	case "created":
+		return provider.TASK_STOPPED, nil
+	case "running":
+		return provider.TASK_RUNNING, nil
+	case "paused":
+		return provider.TASK_PAUSED, nil
+	case "restarting":
+		return provider.TASK_RUNNING, nil // todo(zygimantass): is this sane?
+	case "removing":
+		return provider.TASK_STOPPED, nil
+	case "exited":
+		return provider.TASK_STOPPED, nil
+	case "dead":
+		return provider.TASK_STOPPED, nil
+	}
+
+	return provider.TASK_STATUS_UNDEFINED, nil
+}
+
+func (t *Task) Initialize(ctx context.Context) error {
+	return nil
+}
+
+func (t *Task) Modify(ctx context.Context, td provider.TaskDefinition) error {
+	return nil
+}
+
+func (t *Task) RunCommand(ctx context.Context, cmd []string) (string, string, int, error) {
+	t.provider.logger.Debug("running command", zap.String("id", t.state.Id), zap.Strings("command", cmd))
+
+	exec, err := t.provider.dockerClient.ContainerExecCreate(ctx, t.state.Id, container.ExecOptions{
+		AttachStdout: true,
+		AttachStderr: true,
+		Cmd:          cmd,
+	})
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	resp, err := t.provider.dockerClient.ContainerExecAttach(ctx, exec.ID, container.ExecAttachOptions{})
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	defer resp.Close()
+
+	lastExitCode := 0
+
+	//TODO(Zygimantass): talk with Eric about best practices here
+	ticker := time.NewTicker(1 * time.Second)
+
+	//TODO(Zygimantass): i hate this
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			return "", "", lastExitCode, ctx.Err()
+		case <-ticker.C:
+			execInspect, err := t.provider.dockerClient.ContainerExecInspect(ctx, exec.ID)
+			if err != nil {
+				return "", "", lastExitCode, err
+			}
+
+			if execInspect.Running {
+				continue
+			}
+
+			lastExitCode = execInspect.ExitCode
+			break loop
+		}
+	}
+
+	if err != nil {
+		t.provider.logger.Error("failed to wait for exec", zap.Error(err), zap.String("id", t.state.Id))
+		return "", "", lastExitCode, err
+	}
+
+	var stdout, stderr bytes.Buffer
+	_, err = stdcopy.StdCopy(&stdout, &stderr, resp.Reader)
+	if err != nil {
+		return "", "", lastExitCode, err
+	}
+
+	return stdout.String(), stderr.String(), lastExitCode, nil
+}
+
+func (t *Task) RunCommandWhileStopped(ctx context.Context, cmd []string) (string, string, int, error) {
+	definition := t.GetState().Definition
+	if err := definition.ValidateBasic(); err != nil {
+		return "", "", 0, fmt.Errorf("failed to validate task definition: %w", err)
+	}
+
+	t.provider.logger.Debug("running command while stopped", zap.String("id", t.state.Id), zap.Strings("command", cmd))
+
+	status, err := t.GetStatus(ctx)
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	if status == provider.TASK_RUNNING {
+		return t.RunCommand(ctx, cmd)
+	}
+
+	definition.Entrypoint = []string{"sh", "-c"}
+	definition.Command = []string{"sleep 36000"}
+	definition.ContainerName = fmt.Sprintf("%s-executor-%s-%d", definition.Name, util.RandomString(5), time.Now().Unix())
+	definition.Ports = []string{}
+
+	task, err := t.provider.CreateTask(ctx, definition)
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	err = task.Start(ctx)
+	defer task.Destroy(ctx) // nolint:errcheck
+
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	stdout, stderr, exitCode, err := task.RunCommand(ctx, cmd)
+	if err != nil {
+		return "", "", 0, err
+	}
+
+	return stdout, stderr, exitCode, nil
+}
+
+func (t *Task) GetState() TaskState {
+	t.stateMu.Lock()
+	defer t.stateMu.Unlock()
+	return *t.state
+}
+
+func (t *Task) ensureTask(ctx context.Context) error {
+	state := t.GetState()
+
+	dockerContainer, err := t.provider.dockerClient.ContainerInspect(ctx, state.Id)
+	if err != nil {
+		return fmt.Errorf("failed to inspect container: %w", err)
+	}
+
+	actualStatus, err := t.GetStatus(ctx)
+
+	if err != nil {
+		return fmt.Errorf("failed to get task status: %w", err)
+	}
+
+	if actualStatus != state.Status {
+		return fmt.Errorf("task status mismatch, expected: %d, got: %d", state.Status, actualStatus)
+	}
+
+	// ref: https://github.com/moby/moby/issues/6705
+	if dockerContainer.Name != fmt.Sprintf("/%s", state.Name) {
+		return fmt.Errorf("task name mismatch, expected: %s, got: %s", state.Name, dockerContainer.Name)
+	}
+
+	if err := t.ensureVolume(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *Task) ensureVolume(ctx context.Context) error {
+	if t.state.Volume == nil {
+		return nil
+	}
+
+	volume, err := t.provider.dockerClient.VolumeInspect(ctx, t.state.Volume.Name)
+	if err != nil {
+		return fmt.Errorf("failed to inspect volume: %w", err)
+	}
+
+	if volume.Name != t.state.Volume.Name {
+		return fmt.Errorf("volume name mismatch, expected: %s, got: %s", t.state.Volume.Name, volume.Name)
+	}
+
+	return nil
+}

--- a/core/provider/docker/task_test.go
+++ b/core/provider/docker/task_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestTaskLifecycle(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
 	teardown := setupTest(t, providerName)
@@ -68,7 +68,7 @@ func TestTaskLifecycle(t *testing.T) {
 
 func TestTaskExposingPort(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
 	teardown := setupTest(t, providerName)
@@ -116,7 +116,7 @@ func TestTaskExposingPort(t *testing.T) {
 
 func TestTaskRunCommand(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
 	teardown := setupTest(t, providerName)
@@ -167,7 +167,7 @@ func TestTaskRunCommand(t *testing.T) {
 
 func TestTaskRunCommandWhileStopped(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
 	teardown := setupTest(t, providerName)
@@ -215,7 +215,7 @@ func TestTaskRunCommandWhileStopped(t *testing.T) {
 
 func TestTaskReadWriteFile(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	providerName := gonanoid.MustGenerate(idAlphabet, 10)
 
 	teardown := setupTest(t, providerName)

--- a/core/provider/docker/task_test.go
+++ b/core/provider/docker/task_test.go
@@ -1,0 +1,249 @@
+package docker_test
+
+import (
+	"context"
+	"fmt"
+	"github.com/docker/docker/client"
+	gonanoid "github.com/matoous/go-nanoid/v2"
+	"github.com/skip-mev/petri/core/v2/provider"
+	"github.com/skip-mev/petri/core/v2/provider/docker"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestTaskLifecycle(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+
+	teardown := setupTest(t, providerName)
+	defer teardown(t, providerName)
+
+	p, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+	defer p.Teardown(ctx)
+
+	task, err := p.CreateTask(ctx, provider.TaskDefinition{
+		Name:          "test",
+		ContainerName: "test",
+		Image: provider.ImageDefinition{
+			Image: "nginx:latest",
+			UID:   "1000",
+			GID:   "1000",
+		},
+		Ports: []string{
+			"80",
+		},
+	})
+	require.NoError(t, err)
+
+	state, err := p.SerializeTask(ctx, task)
+	require.NoError(t, err)
+	require.NotEmpty(t, state)
+
+	err = task.Start(ctx)
+	require.NoError(t, err)
+	time.Sleep(time.Second * 5)
+
+	err = task.Stop(ctx)
+	require.NoError(t, err)
+
+	err = task.Destroy(ctx)
+	require.NoError(t, err)
+
+	dockerTask, ok := task.(*docker.Task)
+	require.True(t, ok)
+
+	client, _ := client.NewClientWithOpts()
+	_, err = client.ContainerInspect(ctx, dockerTask.GetState().Id)
+
+	require.Error(t, err)
+}
+
+func TestTaskExposingPort(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+
+	teardown := setupTest(t, providerName)
+	defer teardown(t, providerName)
+
+	p, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+	defer p.Teardown(ctx)
+
+	task, err := p.CreateTask(ctx, provider.TaskDefinition{
+		Name:          "test",
+		ContainerName: "test",
+		Image: provider.ImageDefinition{
+			Image: "nginx:latest",
+			UID:   "1000",
+			GID:   "1000",
+		},
+		Ports: []string{
+			"80",
+		},
+	})
+	require.NoError(t, err)
+
+	state, err := p.SerializeTask(ctx, task)
+	require.NoError(t, err)
+	require.NotEmpty(t, state)
+
+	err = task.Start(ctx)
+	require.NoError(t, err)
+
+	ip, err := task.GetExternalAddress(ctx, "80")
+	require.NoError(t, err)
+	require.NotEmpty(t, ip)
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("http://%s", ip), nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, req)
+
+	err = task.Destroy(ctx)
+	require.NoError(t, err)
+}
+
+func TestTaskRunCommand(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+
+	teardown := setupTest(t, providerName)
+	defer teardown(t, providerName)
+
+	p, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+	defer p.Teardown(ctx)
+
+	task, err := p.CreateTask(ctx, provider.TaskDefinition{
+		Name:          "test",
+		ContainerName: "test",
+		Image: provider.ImageDefinition{
+			Image: "busybox:latest",
+			UID:   "1000",
+			GID:   "1000",
+		},
+		Entrypoint: []string{"sh", "-c"},
+		Command:    []string{"sleep 36000"},
+	})
+	require.NoError(t, err)
+
+	state, err := p.SerializeTask(ctx, task)
+	require.NoError(t, err)
+	require.NotEmpty(t, state)
+
+	err = task.Start(ctx)
+	require.NoError(t, err)
+
+	stdout, stderr, exitCode, err := task.RunCommand(ctx, []string{"sh", "-c", "echo hello"})
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.Empty(t, stderr)
+	require.Equal(t, "hello\n", stdout)
+
+	stdout, stderr, exitCode, err = task.RunCommand(ctx, []string{"sh", "-c", "echo hello >&2"})
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.Empty(t, stdout)
+	require.Equal(t, "hello\n", stderr)
+
+	err = task.Destroy(ctx)
+	require.NoError(t, err)
+}
+
+func TestTaskRunCommandWhileStopped(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+
+	teardown := setupTest(t, providerName)
+	defer teardown(t, providerName)
+
+	p, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+	defer p.Teardown(ctx)
+
+	task, err := p.CreateTask(ctx, provider.TaskDefinition{
+		Name:          "test",
+		ContainerName: "test",
+		Image: provider.ImageDefinition{
+			Image: "busybox:latest",
+			UID:   "1000",
+			GID:   "1000",
+		},
+		Entrypoint: []string{"sh", "-c"},
+		Command:    []string{"sleep 36000"},
+	})
+	require.NoError(t, err)
+
+	state, err := p.SerializeTask(ctx, task)
+	require.NoError(t, err)
+	require.NotEmpty(t, state)
+
+	stdout, stderr, exitCode, err := task.RunCommandWhileStopped(ctx, []string{"sh", "-c", "echo hello"})
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.Empty(t, stderr)
+	require.Equal(t, "hello\n", stdout)
+
+	stdout, stderr, exitCode, err = task.RunCommandWhileStopped(ctx, []string{"sh", "-c", "echo hello >&2"})
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.Empty(t, stdout)
+	require.Equal(t, "hello\n", stderr)
+
+	err = task.Destroy(ctx)
+	require.NoError(t, err)
+}
+
+func TestTaskReadWriteFile(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewDevelopment()
+	providerName := gonanoid.MustGenerate(idAlphabet, 10)
+
+	teardown := setupTest(t, providerName)
+	defer teardown(t, providerName)
+
+	p, err := docker.CreateProvider(ctx, logger, providerName)
+	require.NoError(t, err)
+	defer p.Teardown(ctx)
+
+	task, err := p.CreateTask(ctx, provider.TaskDefinition{
+		Name:          "test",
+		ContainerName: "test",
+		Image: provider.ImageDefinition{
+			Image: "busybox:latest",
+			UID:   "1000",
+			GID:   "1000",
+		},
+		Entrypoint: []string{"sh", "-c"},
+		Command:    []string{"sleep 36000"},
+		DataDir:    "/data",
+	})
+	require.NoError(t, err)
+
+	state, err := p.SerializeTask(ctx, task)
+	require.NoError(t, err)
+	require.NotEmpty(t, state)
+
+	err = task.WriteFile(ctx, "test.txt", []byte("hello world"))
+	require.NoError(t, err)
+
+	stdout, stderr, exitCode, err := task.RunCommandWhileStopped(ctx, []string{"sh", "-c", "cat /data/test.txt"})
+	require.NoError(t, err)
+	require.Equal(t, 0, exitCode)
+	require.Empty(t, stderr)
+	require.Equal(t, "hello world", stdout)
+
+	out, err := task.ReadFile(ctx, "test.txt")
+	require.NoError(t, err)
+	require.Equal(t, "hello world", string(out))
+
+	err = task.Destroy(ctx)
+	require.NoError(t, err)
+}

--- a/core/provider/docker/task_test.go
+++ b/core/provider/docker/task_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/skip-mev/petri/core/v2/provider"
 	"github.com/skip-mev/petri/core/v2/provider/docker"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"net/http"
 	"testing"
 	"time"

--- a/core/provider/docker/task_test.go
+++ b/core/provider/docker/task_test.go
@@ -24,7 +24,10 @@ func TestTaskLifecycle(t *testing.T) {
 
 	p, err := docker.CreateProvider(ctx, logger, providerName)
 	require.NoError(t, err)
-	defer p.Teardown(ctx)
+
+	defer func(ctx context.Context, p provider.ProviderI) {
+		require.NoError(t, p.Teardown(ctx))
+	}(ctx, p)
 
 	task, err := p.CreateTask(ctx, provider.TaskDefinition{
 		Name:          "test",
@@ -73,7 +76,10 @@ func TestTaskExposingPort(t *testing.T) {
 
 	p, err := docker.CreateProvider(ctx, logger, providerName)
 	require.NoError(t, err)
-	defer p.Teardown(ctx)
+
+	defer func(ctx context.Context, p provider.ProviderI) {
+		require.NoError(t, p.Teardown(ctx))
+	}(ctx, p)
 
 	task, err := p.CreateTask(ctx, provider.TaskDefinition{
 		Name:          "test",
@@ -118,7 +124,10 @@ func TestTaskRunCommand(t *testing.T) {
 
 	p, err := docker.CreateProvider(ctx, logger, providerName)
 	require.NoError(t, err)
-	defer p.Teardown(ctx)
+
+	defer func(ctx context.Context, p provider.ProviderI) {
+		require.NoError(t, p.Teardown(ctx))
+	}(ctx, p)
 
 	task, err := p.CreateTask(ctx, provider.TaskDefinition{
 		Name:          "test",
@@ -166,7 +175,10 @@ func TestTaskRunCommandWhileStopped(t *testing.T) {
 
 	p, err := docker.CreateProvider(ctx, logger, providerName)
 	require.NoError(t, err)
-	defer p.Teardown(ctx)
+
+	defer func(ctx context.Context, p provider.ProviderI) {
+		require.NoError(t, p.Teardown(ctx))
+	}(ctx, p)
 
 	task, err := p.CreateTask(ctx, provider.TaskDefinition{
 		Name:          "test",
@@ -211,7 +223,10 @@ func TestTaskReadWriteFile(t *testing.T) {
 
 	p, err := docker.CreateProvider(ctx, logger, providerName)
 	require.NoError(t, err)
-	defer p.Teardown(ctx)
+
+	defer func(ctx context.Context, p provider.ProviderI) {
+		require.NoError(t, p.Teardown(ctx))
+	}(ctx, p)
 
 	task, err := p.CreateTask(ctx, provider.TaskDefinition{
 		Name:          "test",

--- a/core/provider/docker/task_test.go
+++ b/core/provider/docker/task_test.go
@@ -185,13 +185,13 @@ func TestTaskRunCommandWhileStopped(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, state)
 
-	stdout, stderr, exitCode, err := task.RunCommandWhileStopped(ctx, []string{"sh", "-c", "echo hello"})
+	stdout, stderr, exitCode, err := task.RunCommand(ctx, []string{"sh", "-c", "echo hello"})
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 	require.Empty(t, stderr)
 	require.Equal(t, "hello\n", stdout)
 
-	stdout, stderr, exitCode, err = task.RunCommandWhileStopped(ctx, []string{"sh", "-c", "echo hello >&2"})
+	stdout, stderr, exitCode, err = task.RunCommand(ctx, []string{"sh", "-c", "echo hello >&2"})
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 	require.Empty(t, stdout)
@@ -234,7 +234,7 @@ func TestTaskReadWriteFile(t *testing.T) {
 	err = task.WriteFile(ctx, "test.txt", []byte("hello world"))
 	require.NoError(t, err)
 
-	stdout, stderr, exitCode, err := task.RunCommandWhileStopped(ctx, []string{"sh", "-c", "cat /data/test.txt"})
+	stdout, stderr, exitCode, err := task.RunCommand(ctx, []string{"sh", "-c", "cat /data/test.txt"})
 	require.NoError(t, err)
 	require.Equal(t, 0, exitCode)
 	require.Empty(t, stderr)

--- a/core/provider/docker/util.go
+++ b/core/provider/docker/util.go
@@ -1,0 +1,27 @@
+package docker
+
+import (
+	"github.com/docker/go-connections/nat"
+
+	"github.com/skip-mev/petri/core/v2/provider"
+)
+
+func convertTaskDefinitionPortsToPortSet(definition provider.TaskDefinition) nat.PortSet {
+	bindings := nat.PortSet{}
+
+	for _, port := range definition.Ports {
+		bindings[nat.Port(port)] = struct{}{}
+	}
+
+	return bindings
+}
+
+func convertEnvMapToList(env map[string]string) []string {
+	envList := []string{}
+
+	for key, value := range env {
+		envList = append(envList, key+"="+value)
+	}
+
+	return envList
+}

--- a/core/provider/docker/volume.go
+++ b/core/provider/docker/volume.go
@@ -1,0 +1,614 @@
+package docker
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/volume"
+	"github.com/docker/docker/client"
+
+	"github.com/skip-mev/petri/core/v2/provider"
+)
+
+// CreateVolume is an idempotent operation
+func (p *Provider) CreateVolume(ctx context.Context, definition provider.VolumeDefinition) (string, error) {
+	if err := definition.ValidateBasic(); err != nil {
+		return "", fmt.Errorf("failed to validate volume definition: %w", err)
+	}
+
+	p.logger.Debug("creating volume", zap.String("name", definition.Name), zap.String("size", definition.Size))
+
+	existingVolume, err := p.dockerClient.VolumeInspect(ctx, definition.Name)
+
+	if err == nil {
+		return existingVolume.Name, nil
+	}
+
+	createdVolume, err := p.dockerClient.VolumeCreate(ctx, volume.CreateOptions{
+		Name: definition.Name,
+		Labels: map[string]string{
+			providerLabelName: p.GetState().Name,
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return createdVolume.Name, nil
+}
+
+func (p *Provider) DestroyVolume(ctx context.Context, id string) error {
+	p.logger.Info("destroying volume", zap.String("id", id))
+
+	return p.dockerClient.VolumeRemove(ctx, id, true)
+}
+
+func (t *Task) WriteTar(ctx context.Context, relPath string, localTarPath string) error {
+	state := t.GetState()
+	providerState := t.provider.GetState()
+
+	if state.Volume == nil {
+		return fmt.Errorf("no volumes found for container %s", state.Id)
+	}
+
+	volumeName := state.Volume.Name
+
+	logger := t.provider.logger.With(zap.String("volume", state.Id), zap.String("path", relPath))
+
+	logger.Debug("writing file")
+
+	const mountPath = "/mnt/dockervolume"
+
+	containerName := fmt.Sprintf("petri-writefile-%d", time.Now().UnixNano())
+
+	if err := t.provider.pullImage(ctx, providerState.BuilderImageName); err != nil {
+		return err
+	}
+
+	logger.Debug("creating writefile container")
+
+	cc, err := t.provider.dockerClient.ContainerCreate(
+		ctx,
+		&container.Config{
+			Image: providerState.BuilderImageName,
+
+			Entrypoint: []string{"sh", "-c"},
+			Cmd: []string{
+				// Take the uid and gid of the mount path,
+				// and set that as the owner of the new relative path.
+				`chown -R "$(stat -c '%u:%g' "$1")" "$2"`,
+				"_", // Meaningless arg0 for sh -c with positional args.
+				mountPath,
+				mountPath,
+			},
+
+			Labels: map[string]string{
+				providerLabelName: providerState.Name,
+			},
+
+			// Use root user to avoid permission issues when reading files from the volume.
+			User: "0:0",
+		},
+		&container.HostConfig{
+			Binds:      []string{volumeName + ":" + mountPath},
+			AutoRemove: true,
+		},
+		nil, // No networking necessary.
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return fmt.Errorf("creating container: %w", err)
+	}
+
+	logger.Debug("created writefile container", zap.String("id", cc.ID))
+
+	autoRemoved := false
+	defer func() {
+		if autoRemoved {
+			// No need to attempt removing the container if we successfully started and waited for it to complete.
+			return
+		}
+
+		if _, err := t.provider.dockerClient.ContainerInspect(ctx, cc.ID); err != nil && client.IsErrNotFound(err) {
+			// auto-removed, but not detected as autoremoved
+			return
+		}
+
+		if err := t.provider.dockerClient.ContainerRemove(ctx, cc.ID, container.RemoveOptions{
+			Force: true,
+		}); err != nil {
+			logger.Error("failed to remove writefile container", zap.String("id", cc.ID), zap.Error(err))
+		}
+	}()
+
+	logger.Debug("copying file to container")
+
+	file, err := os.Open(localTarPath)
+
+	if err != nil {
+		return fmt.Errorf("opening file: %w", err)
+	}
+
+	defer file.Close()
+
+	if err := t.provider.dockerClient.CopyToContainer(
+		ctx,
+		cc.ID,
+		mountPath,
+		file,
+		container.CopyToContainerOptions{},
+	); err != nil {
+		return fmt.Errorf("copying tar to container: %w", err)
+	}
+
+	logger.Debug("starting writefile container")
+	if err := t.provider.dockerClient.ContainerStart(ctx, cc.ID, container.StartOptions{}); err != nil {
+		return fmt.Errorf("starting write-file container: %w", err)
+	}
+
+	waitCh, errCh := t.provider.dockerClient.ContainerWait(ctx, cc.ID, container.WaitConditionNotRunning)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	case res := <-waitCh:
+		autoRemoved = true
+
+		if res.Error != nil {
+			return fmt.Errorf("waiting for write-file container: %s", res.Error.Message)
+		}
+
+		if res.StatusCode != 0 {
+			return fmt.Errorf("chown on new file exited %d", res.StatusCode)
+		}
+	}
+
+	return nil
+}
+
+// taken from strangelove-ventures/interchain-test
+func (t *Task) WriteFile(ctx context.Context, relPath string, content []byte) error {
+	state := t.GetState()
+	providerState := t.provider.GetState()
+
+	if state.Volume == nil {
+		return fmt.Errorf("no volumes found for container %s", state.Id)
+	}
+
+	volumeName := state.Volume.Name
+
+	logger := t.provider.logger.With(zap.String("volume", volumeName), zap.String("path", relPath))
+
+	logger.Debug("writing file")
+
+	const mountPath = "/mnt/dockervolume"
+
+	containerName := fmt.Sprintf("petri-writefile-%d", time.Now().UnixNano())
+
+	if err := t.provider.pullImage(ctx, providerState.BuilderImageName); err != nil {
+		return err
+	}
+
+	logger.Debug("creating writefile container")
+
+	cc, err := t.provider.dockerClient.ContainerCreate(
+		ctx,
+		&container.Config{
+			Image: providerState.BuilderImageName,
+
+			Entrypoint: []string{"sh", "-c"},
+			Cmd: []string{
+				// Take the uid and gid of the mount path,
+				// and set that as the owner of the new relative path.
+				`chown -R "$(stat -c '%u:%g' "$1")" "$2"`,
+				"_", // Meaningless arg0 for sh -c with positional args.
+				mountPath,
+				mountPath,
+			},
+
+			Labels: map[string]string{
+				providerLabelName: providerState.Name,
+			},
+
+			// Use root user to avoid permission issues when reading files from the volume.
+			User: "0:0",
+		},
+		&container.HostConfig{
+			Binds:      []string{volumeName + ":" + mountPath},
+			AutoRemove: true,
+		},
+		nil, // No networking necessary.
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return fmt.Errorf("creating container: %w", err)
+	}
+
+	logger.Debug("created writefile container", zap.String("id", cc.ID))
+
+	autoRemoved := false
+	defer func() {
+		if autoRemoved {
+			// No need to attempt removing the container if we successfully started and waited for it to complete.
+			return
+		}
+
+		if _, err := t.provider.dockerClient.ContainerInspect(ctx, cc.ID); err != nil && client.IsErrNotFound(err) {
+			// auto-removed, but not detected as autoremoved
+			return
+		}
+
+		if err := t.provider.dockerClient.ContainerRemove(ctx, cc.ID, container.RemoveOptions{
+			Force: true,
+		}); err != nil {
+			logger.Error("failed to remove writefile container", zap.String("id", cc.ID), zap.Error(err))
+		}
+	}()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: relPath,
+
+		Size: int64(len(content)),
+		Mode: 0o600,
+		// Not setting uname because the container will chown it anyway.
+		ModTime: time.Now(),
+
+		Format: tar.FormatPAX,
+	}); err != nil {
+		return fmt.Errorf("writing tar header: %w", err)
+	}
+	if _, err := tw.Write(content); err != nil {
+		return fmt.Errorf("writing content to tar: %w", err)
+	}
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("closing tar writer: %w", err)
+	}
+
+	logger.Debug("copying file to container")
+
+	if err := t.provider.dockerClient.CopyToContainer(
+		ctx,
+		cc.ID,
+		mountPath,
+		&buf,
+		container.CopyToContainerOptions{},
+	); err != nil {
+		return fmt.Errorf("copying tar to container: %w", err)
+	}
+
+	logger.Debug("starting writefile container")
+	if err := t.provider.dockerClient.ContainerStart(ctx, cc.ID, container.StartOptions{}); err != nil {
+		return fmt.Errorf("starting write-file container: %w", err)
+	}
+
+	waitCh, errCh := t.provider.dockerClient.ContainerWait(ctx, cc.ID, container.WaitConditionNotRunning)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	case res := <-waitCh:
+		autoRemoved = true
+
+		if res.Error != nil {
+			return fmt.Errorf("waiting for write-file container: %s", res.Error.Message)
+		}
+
+		if res.StatusCode != 0 {
+			return fmt.Errorf("chown on new file exited %d", res.StatusCode)
+		}
+	}
+
+	return nil
+}
+
+func (t *Task) ReadFile(ctx context.Context, relPath string) ([]byte, error) {
+	state := t.GetState()
+	providerState := t.provider.GetState()
+
+	if state.Volume == nil {
+		return nil, fmt.Errorf("no volumes found for container %s", state.Id)
+	}
+
+	volumeName := state.Volume.Name
+
+	logger := t.provider.logger.With(zap.String("volume", volumeName), zap.String("path", relPath))
+
+	const mountPath = "/mnt/dockervolume"
+
+	containerName := fmt.Sprintf("petri-getfile-%d", time.Now().UnixNano())
+
+	if err := t.provider.pullImage(ctx, providerState.BuilderImageName); err != nil {
+		return nil, err
+	}
+
+	logger.Debug("creating getfile container")
+
+	cc, err := t.provider.dockerClient.ContainerCreate(
+		ctx,
+		&container.Config{
+			Image: providerState.BuilderImageName,
+
+			Labels: map[string]string{
+				providerLabelName: providerState.Name,
+			},
+
+			// Use root user to avoid permission issues when reading files from the volume.
+			User: "0",
+		},
+		&container.HostConfig{
+			Binds: []string{volumeName + ":" + mountPath},
+			// AutoRemove: true,
+		},
+		nil, // No networking necessary.
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating container: %w", err)
+	}
+
+	logger.Debug("created getfile container", zap.String("id", cc.ID))
+
+	defer func() {
+		if _, err := t.provider.dockerClient.ContainerInspect(ctx, cc.ID); err != nil && client.IsErrNotFound(err) {
+			// auto-removed, but not detected as autoremoved
+			return
+		}
+
+		if err := t.provider.dockerClient.ContainerRemove(ctx, cc.ID, container.RemoveOptions{
+			Force: true,
+		}); err != nil {
+			logger.Error("failed cleaning up the getfile container", zap.Error(err))
+		}
+	}()
+
+	logger.Debug("copying from container")
+	rc, _, err := t.provider.dockerClient.CopyFromContainer(ctx, cc.ID, path.Join(mountPath, relPath))
+	if err != nil {
+		return nil, fmt.Errorf("copying from container: %w", err)
+	}
+	defer func() {
+		_ = rc.Close()
+	}()
+
+	wantPath := path.Base(relPath)
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading tar from container: %w", err)
+		}
+		if hdr.Name != wantPath {
+			continue
+		}
+
+		return io.ReadAll(tr)
+	}
+
+	return nil, fmt.Errorf("path %q not found in tar from container", relPath)
+}
+
+func (t *Task) DownloadDir(ctx context.Context, relPath, localPath string) error {
+	state := t.GetState()
+	providerState := t.provider.GetState()
+
+	if state.Volume == nil {
+		return fmt.Errorf("no volumes found for container %s", state.Id)
+	}
+
+	volumeName := state.Volume.Name
+
+	logger := t.provider.logger.With(zap.String("volume", volumeName), zap.String("path", relPath), zap.String("localPath", localPath))
+
+	const mountPath = "/mnt/dockervolume"
+
+	containerName := fmt.Sprintf("petri-getdir-%d", time.Now().UnixNano())
+
+	logger.Debug("creating getdir container")
+
+	if err := t.provider.pullImage(ctx, providerState.BuilderImageName); err != nil {
+		return err
+	}
+
+	cc, err := t.provider.dockerClient.ContainerCreate(
+		ctx,
+		&container.Config{
+			Image: providerState.BuilderImageName,
+
+			Labels: map[string]string{
+				providerLabelName: providerState.Name,
+			},
+
+			// Use root user to avoid permission issues when reading files from the volume.
+			User: "0",
+		},
+		&container.HostConfig{
+			Binds:      []string{volumeName + ":" + mountPath},
+			AutoRemove: true,
+		},
+		nil, // No networking necessary.
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return fmt.Errorf("creating container: %w", err)
+	}
+
+	defer func() {
+		if _, err := t.provider.dockerClient.ContainerInspect(ctx, cc.ID); err != nil && client.IsErrNotFound(err) {
+			return
+		}
+
+		if err := t.provider.dockerClient.ContainerRemove(ctx, cc.ID, container.RemoveOptions{
+			Force: true,
+		}); err != nil {
+			logger.Error("failed cleaning up the getdir container", zap.Error(err))
+		}
+	}()
+
+	logger.Debug("copying from container")
+	reader, _, err := t.provider.dockerClient.CopyFromContainer(ctx, cc.ID, path.Join(mountPath, relPath))
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(localPath, os.ModePerm); err != nil {
+		return err
+	}
+	tr := tar.NewReader(reader)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break // End of archive
+		}
+		if err != nil {
+			return err
+		}
+
+		var fileBuff bytes.Buffer
+		if _, err := io.Copy(&fileBuff, tr); err != nil {
+			return err
+		}
+
+		name := hdr.Name
+		extractedFileName := path.Base(name)
+		isDirectory := extractedFileName == ""
+		if isDirectory {
+			continue
+		}
+
+		filePath := filepath.Join(localPath, extractedFileName)
+		if err := os.WriteFile(filePath, fileBuff.Bytes(), os.ModePerm); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *Provider) SetVolumeOwner(ctx context.Context, volumeName, uid, gid string) error {
+	logger := p.logger.With(zap.String("volume", volumeName), zap.String("uid", uid), zap.String("gid", gid))
+
+	const mountPath = "/mnt/dockervolume"
+
+	containerName := fmt.Sprintf("petri-setowner-%d", time.Now().UnixNano())
+
+	if err := p.pullImage(ctx, p.GetState().BuilderImageName); err != nil {
+		return err
+	}
+
+	logger.Debug("creating volume-owner container")
+
+	cc, err := p.dockerClient.ContainerCreate(
+		ctx,
+		&container.Config{
+			Image:      p.GetState().BuilderImageName,
+			Entrypoint: []string{"sh", "-c"},
+			Cmd: []string{
+				`chown "$2:$3" "$1" && chmod 0700 "$1"`,
+				"_", // Meaningless arg0 for sh -c with positional args.
+				mountPath,
+				uid,
+				gid,
+			},
+			Labels: map[string]string{
+				providerLabelName: p.GetState().Name,
+			},
+			// Use root user to avoid permission issues when reading files from the volume.
+			User: "0",
+		},
+		&container.HostConfig{
+			Binds:      []string{volumeName + ":" + mountPath},
+			AutoRemove: true,
+		},
+		nil, // No networking necessary.
+		nil,
+		containerName,
+	)
+	if err != nil {
+		return fmt.Errorf("creating container: %w", err)
+	}
+	autoRemoved := false
+	defer func() {
+		if autoRemoved {
+			// No need to attempt removing the container if we successfully started and waited for it to complete.
+			return
+		}
+
+		if _, err := p.dockerClient.ContainerInspect(ctx, cc.ID); err != nil && client.IsErrNotFound(err) {
+			// auto-removed, but not detected as autoremoved
+			return
+		}
+
+		if err := p.dockerClient.ContainerRemove(ctx, cc.ID, container.RemoveOptions{
+			Force: true,
+		}); err != nil {
+			logger.Error("failed cleaning up the volume-owner container", zap.Error(err))
+		}
+	}()
+
+	logger.Debug("starting volume-owner container")
+	if err := p.dockerClient.ContainerStart(ctx, cc.ID, container.StartOptions{}); err != nil {
+		return fmt.Errorf("starting volume-owner container: %w", err)
+	}
+
+	waitCh, errCh := p.dockerClient.ContainerWait(ctx, cc.ID, container.WaitConditionNotRunning)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	case res := <-waitCh:
+		autoRemoved = true
+
+		if res.Error != nil {
+			return fmt.Errorf("waiting for volume-owner container: %s", res.Error.Message)
+		}
+
+		if res.StatusCode != 0 {
+			return fmt.Errorf("configuring volume exited %d", res.StatusCode)
+		}
+	}
+
+	return nil
+}
+
+func (p *Provider) teardownVolumes(ctx context.Context) error {
+	p.logger.Debug("tearing down docker volumes")
+
+	volumes, err := p.dockerClient.VolumeList(ctx, volume.ListOptions{
+		Filters: filters.NewArgs(filters.Arg("label", fmt.Sprintf("%s=%s", providerLabelName, p.GetState().Name))),
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, filteredVolume := range volumes.Volumes {
+		err := p.DestroyVolume(ctx, filteredVolume.Name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/core/provider/provider.go
+++ b/core/provider/provider.go
@@ -31,7 +31,6 @@ type Task struct {
 }
 
 type TaskI interface {
-	Initialize(context.Context) error
 	Start(context.Context) error
 	Stop(context.Context) error
 	Destroy(context.Context) error


### PR DESCRIPTION
Rewriting the docker provider to conform to the new ProviderI and TaskI interfaces. The logic is mostly unchanged aside from adding tests to confirm behaviour is correct.