### PR TITLE
Add docker auth to digital ocean provider

### DIFF
--- a/core/provider/digitalocean/provider.go
+++ b/core/provider/digitalocean/provider.go
@@ -191,7 +191,9 @@ func (p *Provider) CreateTask(ctx context.Context, definition provider.TaskDefin
 	_, _, err = task.dockerClient.ImageInspectWithRaw(ctx, definition.Image.Image)
 	if err != nil {
 		p.logger.Info("image not found, pulling", zap.String("image", definition.Image.Image))
-		if err = task.dockerClient.ImagePull(ctx, p.logger, definition.Image.Image, image.PullOptions{}); err != nil {
+		if err = task.dockerClient.ImagePull(ctx, p.logger, definition.Image.Image, image.PullOptions{
+			RegistryAuth: doConfig["docker_auth"],
+		}); err != nil {
 			return nil, err
 		}
 	}

--- a/core/provider/digitalocean/types.go
+++ b/core/provider/digitalocean/types.go
@@ -22,5 +22,9 @@ func (d DigitalOceanTaskConfig) ValidateBasic() error {
 		return fmt.Errorf("image_id has to be an integer")
 	}
 
+	if v, ok := d["docker_auth"]; !ok || v == "" {
+		return fmt.Errorf("docker_auth has to be non-empty")
+	}
+
 	return nil
 }


### PR DESCRIPTION
Adds docker auth to the digital ocean provider--set in the task config. 
Closes https://linear.app/cosmoslabs/issue/STACK-1362/ironbird-docker-retryable-errors 
