### PR TITLE
feat: Add pyroscope

### DIFF
--- a/contrib/digitalocean/files/config.alloy
+++ b/contrib/digitalocean/files/config.alloy
@@ -80,3 +80,37 @@ loki.write "overseer" {
      }
    }
 }
+
+pyroscope.scrape "node" {
+          targets = [
+            {"__address__" = "localhost:6060", "service_name" = "ironbird", "host" = coalesce(sys.env("HOSTNAME"), constants.hostname)},
+          ]
+          profiling_config {
+            profile.memory {
+              enabled = true
+            }
+            profile.block {
+              enabled = true
+            }
+            profile.goroutine {
+              enabled = true
+            }
+            profile.mutex {
+              enabled = true
+            }
+            profile.process_cpu {
+              enabled = true
+            }
+        }
+      forward_to = [pyroscope.write.grafana_cloud.receiver]
+}
+
+pyroscope.write "grafana_cloud" {
+  endpoint {
+    url = json_path(local.file.creds.content, ".pyroscope.url")[0]
+    basic_auth {
+      username = "<GRAF_PYRO_USER>"
+      password = "<GRAF_PYRO_PASS>"
+    }
+  }
+}

--- a/contrib/docs/digitalocean.md
+++ b/contrib/docs/digitalocean.md
@@ -19,8 +19,9 @@ as you would use the Docker provider.
 
 1. Rename the `contrib/digitalocean/petri_docker.pkr.hcl.example` file to `contrib/digitalocean/petri_docker.pkr.hcl`
 2. Replace `<DO_API_TOKEN>` with your DigitalOcean API token 
-3. Include the regions you're going to run Petri on in the "snapshot_regions" variable.
-4. Run `packer build petri_docker.pkr.hcl`
+3. Replace `<GRAF_PYRO_USER>` and `<GRAF_PYRO_PASS>` in `config.alloy` with your Grafana username and password for Pyroscope profiling data publication.
+4. Include the regions you're going to run Petri on in the "snapshot_regions" variable.
+5. Run `packer build petri_docker.pkr.hcl`
 
 ### Finding the image ID of your snapshot
 

--- a/core/provider/digitalocean/telemetry.go
+++ b/core/provider/digitalocean/telemetry.go
@@ -17,14 +17,20 @@ type LokiSettings struct {
 	URL      string `json:"url"`
 }
 
+type PyroscopeSettings struct {
+	URL string `json:"url"`
+}
+
 type TelemetrySettings struct {
 	Prometheus PrometheusSettings `json:"prometheus"`
 	Loki       LokiSettings       `json:"loki"`
+	Pyroscope  PyroscopeSettings  `json:"pyroscope"`
 }
 
 type TelemetryConfig struct {
 	Prometheus PrometheusSettings `json:"prometheus"`
 	Loki       LokiSettings       `json:"loki"`
+	Pyroscope  PyroscopeSettings  `json:"pyroscope"`
 	Provider   string             `json:"provider"`
 }
 
@@ -32,6 +38,7 @@ func (t *TelemetrySettings) GetCommand(provider string) ([]string, error) {
 	telemetryConfig := TelemetryConfig{
 		Prometheus: t.Prometheus,
 		Loki:       t.Loki,
+		Pyroscope:  t.Pyroscope,
 		Provider:   provider,
 	}
 

--- a/cosmos/node/node.go
+++ b/cosmos/node/node.go
@@ -61,11 +61,12 @@ func CreateNode(ctx context.Context, logger *zap.Logger, infraProvider provider.
 	node.logger.Info("creating node", zap.String("name", nodeConfig.Name))
 
 	def := provider.TaskDefinition{
-		Name:       nodeConfig.Name,
-		Image:      chainConfig.Image,
-		Ports:      append([]string{"9090", "26656", "26657", "26660", "1317"}, chainConfig.AdditionalPorts...),
-		Entrypoint: append([]string{chainConfig.BinaryName, "--home", chainConfig.HomeDir, "start"}, chainConfig.AdditionalStartFlags...),
-		DataDir:    chainConfig.HomeDir,
+		Name:        nodeConfig.Name,
+		Image:       chainConfig.Image,
+		Ports:       append([]string{"9090", "26656", "26657", "26660", "1317"}, chainConfig.AdditionalPorts...),
+		Entrypoint:  append([]string{chainConfig.BinaryName, "--home", chainConfig.HomeDir, "start"}, chainConfig.AdditionalStartFlags...),
+		DataDir:     chainConfig.HomeDir,
+		Environment: map[string]string{"GODEBUG": "blockprofilerate=1"},
 	}
 
 	if opts.NodeDefinitionModifier != nil {


### PR DESCRIPTION
Adds pyroscope scraping to alloy.

I've only added the endpoint to the config so as not to commit the creds to the ironbird repo--they are now build into the DO images.

I've also added an env variable to the docker launch so that we can get blocking data from the pprof endpoint.

Closes: STACK-1397