### PR TITLE
feat: Add Entrypoint

### DIFF
--- a/core/types/chain.go
+++ b/core/types/chain.go
@@ -65,7 +65,8 @@ type ChainConfig struct {
 	NumValidators int    // NumValidators is the number of validators to create
 	NumNodes      int    // NumNodes is the number of nodes to create
 
-	BinaryName string // BinaryName is the name of the chain binary in the Docker image
+	BinaryName string   // BinaryName is the name of the chain binary in the Docker image
+	Entrypoint []string // Entrypoint is the list of arguments to invoke in the entrypoint of the Docker image
 
 	Image provider.ImageDefinition // Image is the Docker ImageDefinition of the chain
 

--- a/cosmos/node/init.go
+++ b/cosmos/node/init.go
@@ -22,5 +22,14 @@ func (n *Node) InitHome(ctx context.Context) error {
 		return fmt.Errorf("failed to init home (exit code %d): %s, stdout: %s", exitCode, stderr, stdout)
 	}
 
+	clientConfig := GenerateDefaultClientConfig(n.GetChainConfig().ChainId)
+	if err := n.ModifyTomlConfigFile(
+		ctx,
+		"config/client.toml",
+		clientConfig,
+	); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/cosmos/node/node.go
+++ b/cosmos/node/node.go
@@ -60,11 +60,18 @@ func CreateNode(ctx context.Context, logger *zap.Logger, infraProvider provider.
 
 	node.logger.Info("creating node", zap.String("name", nodeConfig.Name))
 
+	entrypoint := []string{chainConfig.BinaryName}
+	if len(chainConfig.Entrypoint) > 0 {
+		entrypoint = chainConfig.Entrypoint
+	}
+
 	def := provider.TaskDefinition{
-		Name:        nodeConfig.Name,
-		Image:       chainConfig.Image,
-		Ports:       append([]string{"9090", "26656", "26657", "26660", "1317"}, chainConfig.AdditionalPorts...),
-		Entrypoint:  append([]string{chainConfig.BinaryName, "--home", chainConfig.HomeDir, "start"}, chainConfig.AdditionalStartFlags...),
+		Name:  nodeConfig.Name,
+		Image: chainConfig.Image,
+		Ports: append([]string{"9090", "26656", "26657", "26660", "1317"}, chainConfig.AdditionalPorts...),
+		Entrypoint: append(
+			append(entrypoint, "--home", chainConfig.HomeDir, "start"),
+			chainConfig.AdditionalStartFlags...),
 		DataDir:     chainConfig.HomeDir,
 		Environment: map[string]string{"GODEBUG": "blockprofilerate=1"},
 	}


### PR DESCRIPTION
Allows you to specify an entrypoint to be used in the docker container for a chain. Currently entrypoint is used, but specifies `<binary> start`. Whereas now we can run any arbitrary entrypoint and still provide the binary argument to be used for things like `gentx`.

Also adds some hacky retrying on docker pull failures that gets around rate limiting when running large networks.